### PR TITLE
Bump version to 0.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "anac"
-version = "0.1.1"
+version = "0.1.2"
 description = "Async NetBox API Client"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
What's Changed
====

- `dev` by @timeforplanb123 in #1: 
  - Add `nox` sessions with `noxfile.py`
  - Add unit tests for `api.py` module
  - Add linting, typing, testing, code coverage dev packages, pytest and coverage options to `pyproject.toml`
  - Add new github pipelines, `commit.yml` and `coverage.yml`
  - Add `.flake8`, `mypy.ini` configuration files
  - Add unit tests / coverage reports to .gitignore
  - Add new code coverage badge to `README.md`, add `PyPI` badge logo
  - Change import statemenets (groups and order) with `flake8-import-order` plugin and `import-order-style = google` `.flake8` option. `Black` reformatting with `max-line-length = 88`
  - Change single-sourcing package version (`anac/core/__init__`), using standard `importlib.metadata` library (it's possible from Python 3.8) instead of `pkg_resources` library